### PR TITLE
Load editor type from $EDITOR env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ wget -O gonote https://github.com/exaroth/gonote/releases/download/0.1.0/gonote-
 
 - **Creating notes**
 
-`gonote` - Will open external editor (by default vim) allowing you to create new note.
+`gonote` - Will open external editor (set in `$EDITOR` environment variable) allowing you to create new note.
 
 `gonote @sometag @anothertag` - Same as above but will also attach @sometag and @anothertag to the note.
 
@@ -57,11 +57,10 @@ wget -O gonote https://github.com/exaroth/gonote/releases/download/0.1.0/gonote-
 
 `gonote delete <note_id> --permanently` - Will permanently delete a note.
 
-### Configuration file
+### Configuration
 You can find configuration file in ~/.gonote.json.
 Available options are:
 - `email` - SimpleNote email.
 - `password` - SimpleNote password.
-- `editor` - Editor to use (vim by default).
 - `markdown` - Whether to set markdown flag when uploading notes.
 

--- a/cmd.go
+++ b/cmd.go
@@ -177,7 +177,7 @@ func (c *commandLineParser) parse(args []string) (err error) {
 		if len(flagless) > 0 {
 			c.Params.Content = strings.Join(flagless, " ")
 		} else {
-			content, err := WriteToFile("", c.config.Editor)
+			content, err := WriteToFile("")
 			if err != nil {
 				return err
 			}

--- a/config.go
+++ b/config.go
@@ -15,7 +15,6 @@ import (
 const (
 	defaultConfigFilename = ".gonote.json"
 	defaultMarkdownOption = true
-	defaultEditorOption   = "vim"
 )
 
 // Main configuration interface used to interact with configuration file.
@@ -36,7 +35,6 @@ type UserConfigFile struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
 	Markdown bool   `json:"markdown"`
-	Editor   string `json:"editor"`
 }
 
 // Return new configation instance.
@@ -46,7 +44,6 @@ func NewConfigFile() MainConfig {
 		Path: path.Join(usr.HomeDir, defaultConfigFilename),
 		UserCfg: &UserConfigFile{
 			Markdown: defaultMarkdownOption,
-			Editor:   defaultEditorOption,
 		},
 	}
 }
@@ -103,7 +100,6 @@ func (c *mainConfig) create() (err error) {
 	fmt.Println("Enter SimpleNote password:")
 	c.UserCfg.Password, err = reader.ReadString('\n')
 	c.UserCfg.Password = strings.TrimSpace(c.UserCfg.Password)
-	c.UserCfg.Editor = defaultEditorOption
 	if err != nil {
 		return
 	}

--- a/simplenote.go
+++ b/simplenote.go
@@ -167,7 +167,7 @@ func (s *simpleNoteClient) editNote() (err error) {
 		Key: s.Params.Key,
 	}
 	note := s.fetchNote(n)
-	updatedContent, err := WriteToFile(note.Content, s.Cfg.Editor)
+	updatedContent, err := WriteToFile(note.Content)
 	if err != nil {
 		return err
 	}

--- a/utils.go
+++ b/utils.go
@@ -13,6 +13,9 @@ import (
 
 var Version = "0.1.0"
 
+// Default editor to be used if for some reason $EDITOR env variable is not set
+const defaultEditor = "vim"
+
 // List current GoNote version.
 func ListVersion() string {
 	return fmt.Sprintf("GoNote Ver.%s", Version)
@@ -71,8 +74,12 @@ func ParseTags(tags []string) (tagString string) {
 }
 
 // writeToFile opens external editor with predetermined temporary file
-// after editor is closed reads data from the file and deletes it.
-func WriteToFile(prevContent, editor string) (content string, err error) {
+// after editor is closed reads data from the temp file and deletes it.
+func WriteToFile(prevContent string) (content string, err error) {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = defaultEditor
+	}
 	fpath := path.Join(os.TempDir(), GenerateRandomHandle())
 	f, err := os.Create(fpath)
 	if err != nil {


### PR DESCRIPTION
This allows loading editor type from $EDITOR env variable instead of loading it from config file.  https://github.com/exaroth/gonote/issues/4